### PR TITLE
Added selector to local.css so first para of chapter has no indent.

### DIFF
--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -55,6 +55,10 @@ footer{
 	text-align: right;
 }
 
+section[epub|type~="chapter"] p:first-of-type{
+	text-indent: 0;
+}
+
 header p{
 	text-align: center;
 	font-variant: small-caps;


### PR DESCRIPTION
I noticed in reading through the recently released edition that the first paragraph in each chapter is (like all other paras) indented, which is not SE style. First para shouldn't be indented. Added a selector to local.css to fix this, as follows, but it may not be the best solution!

`section[epub|type~="chapter"] p:first-of-type{`
	`text-indent: 0;`
`}`

Best solution is probably to add a h4 selector to core.css like this, but I figured I don't have authorisation for that:

`blockquote + p,`
`blockquote p:first-child,`
`h2 + p,`
`h3 + p,`
**h4 + p,**
`header + p,`
`hr + p,`
`section[epub|type~="rearnotes"] > ol > li > p:first-child{`
`	text-indent: 0;`
`}`